### PR TITLE
Wire feed events to shelter actions and fix supporting issues

### DIFF
--- a/backend/dao/feed_events.js
+++ b/backend/dao/feed_events.js
@@ -1,4 +1,14 @@
+import crypto from 'node:crypto';
 import db from '../db/index.js';
+
+export async function createFeedEvent(eventType, { shelter_id = null, pet_id = null, post_id = null, payload = null } = {}) {
+  const id = crypto.randomUUID();
+  await db.query(
+    `INSERT INTO feed_events (id, event_type, shelter_id, pet_id, post_id, payload)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    [id, eventType, shelter_id, pet_id, post_id, payload ? JSON.stringify(payload) : null]
+  );
+}
 
 export async function listRecentActivity(limit = 25) {
   const safeLimit = Math.max(1, Math.min(Number(limit) || 25, 100));

--- a/backend/db/seed.sql
+++ b/backend/db/seed.sql
@@ -43,14 +43,14 @@ JOIN pets p
 WHERE u.username = 'adopter1';
 
 INSERT INTO feed_events (event_type, shelter_id, post_id)
-SELECT type, shelter_id, id
+SELECT 'shelter_post', shelter_id, id
 FROM shelter_posts sp
 WHERE sp.title = 'Adoption Event This Weekend';
 
 INSERT INTO feed_events (event_type, shelter_id, pet_id, payload)
-SELECT 'PET_CREATED', s.id, p.id, JSON_OBJECT('pet_name', p.name)
+SELECT 'new_pet', s.id, p.id, JSON_OBJECT('title', CONCAT('New pet: ', p.name), 'body', p.description, 'primaryPhotoUrl', NULL)
 FROM shelters s
-JOIN pets p 
+JOIN pets p
 	ON p.shelter_id = s.id
 WHERE s.name = 'Happy Tails Shelter';
 

--- a/backend/routes/pets.js
+++ b/backend/routes/pets.js
@@ -9,6 +9,7 @@ import {
 } from '../dao/pets.js';
 import { getShelterByUserId } from '../dao/shelters.js';
 import { requireAuth, requireRole } from '../middleware/auth.js';
+import { createFeedEvent } from '../dao/feed_events.js';
 
 const router = express.Router();
 
@@ -43,6 +44,21 @@ router.post('/', requireAuth, requireRole('shelter_admin'), asyncHandler(async f
         description: description,
         status: status
     });
+
+    try {
+        await createFeedEvent('new_pet', {
+            shelter_id: shelter.id,
+            pet_id: created.id,
+            payload: {
+                title: `New pet: ${name}`,
+                body: description || `${name} is now available at ${shelter.name}.`,
+                primaryPhotoUrl: null,
+            },
+        });
+    } catch (e) {
+        console.error('Failed to create feed event for new pet:', e);
+    }
+
     res.status(201).json(created);
 }));
 
@@ -97,6 +113,22 @@ router.put('/:id', requireAuth, requireRole('shelter_admin'), asyncHandler(async
     const updated = await updatePet(req.params.id, fields);
     if (!updated) {
         return res.status(404).json({ error: 'Pet not found' });
+    }
+
+    if (fields.status === 'adopted' || fields.status === 'available') {
+        const eventType = fields.status === 'adopted' ? 'adoption_event' : 'status_change';
+        const title = fields.status === 'adopted'
+            ? `${pet.name} has been adopted!`
+            : `${pet.name} is available for adoption`;
+        try {
+            await createFeedEvent(eventType, {
+                shelter_id: shelter.id,
+                pet_id: pet.id,
+                payload: { title, body: null, primaryPhotoUrl: null },
+            });
+        } catch (e) {
+            console.error('Failed to create feed event for pet status change:', e);
+        }
     }
 
     res.json(updated);

--- a/backend/routes/shelter_posts.js
+++ b/backend/routes/shelter_posts.js
@@ -8,6 +8,7 @@ import {
 } from '../dao/shelter_posts.js';
 import { getShelterByUserId } from '../dao/shelters.js';
 import { requireAuth, requireRole } from '../middleware/auth.js';
+import { createFeedEvent } from '../dao/feed_events.js';
 
 const router = express.Router();
 
@@ -42,6 +43,19 @@ router.post('/', requireAuth, requireRole('shelter_admin'), asyncHandler(async f
         body: body,
         publishedAt: publish ? new Date() : null
     });
+
+    if (publish) {
+        try {
+            await createFeedEvent('shelter_post', {
+                shelter_id: shelter_id,
+                pet_id: pet_id,
+                post_id: created.id,
+                payload: { title, body, primaryPhotoUrl: null },
+            });
+        } catch (e) {
+            console.error('Failed to create feed event for shelter post:', e);
+        }
+    }
 
     res.status(201).json(created);
 }));
@@ -116,6 +130,18 @@ router.patch('/:id/publish', requireAuth, requireRole('shelter_admin'), asyncHan
     }
 
     const updated = await publishShelterPost(postId);
+
+    try {
+        await createFeedEvent('shelter_post', {
+            shelter_id: existing.shelter_id,
+            pet_id: existing.pet_id || null,
+            post_id: postId,
+            payload: { title: existing.title, body: existing.body, primaryPhotoUrl: null },
+        });
+    } catch (e) {
+        console.error('Failed to create feed event for published post:', e);
+    }
+
     res.json(updated);
 }));
 

--- a/backend/scripts/run_tests.js
+++ b/backend/scripts/run_tests.js
@@ -28,7 +28,7 @@ export async function runTests() {
         const configPath = path.join(backendRoot, 'jest.config.cjs');
         const jestBin = path.join(backendRoot, 'node_modules', 'jest', 'bin', 'jest.js');
 
-        const child = spawn(process.execPath, ['--experimental-vm-modules', jestBin, '--config', configPath], {
+        const child = spawn(process.execPath, ['--experimental-vm-modules', jestBin, '--config', configPath, '--runInBand'], {
             stdio: 'inherit',
             shell: false,
             cwd: backendRoot

--- a/backend/tests/feed_events.test.js
+++ b/backend/tests/feed_events.test.js
@@ -33,4 +33,111 @@ describe('feed_events endpoints', function () {
 
     expect(Array.isArray(res.body) || Array.isArray(res.body.items)).toBe(true);
   });
+
+  it('creating a pet emits a new_pet feed event', async function () {
+    const { shelterId, token } = await createShelter();
+
+    const pet = await request(app)
+      .post('/pets')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ name: 'Biscuit', species: 'Dog' })
+      .expect(201);
+
+    const feed = await request(app).get('/feed_events?limit=100').expect(200);
+    const events = Array.isArray(feed.body) ? feed.body : feed.body.items;
+    const match = events.find(function (e) {
+      return e.event_type === 'new_pet' && e.pet_id === pet.body.id;
+    });
+
+    expect(match).toBeDefined();
+  });
+
+  it('updating a pet status to adopted emits an adoption_event', async function () {
+    const { shelterId, token } = await createShelter();
+
+    const pet = await request(app)
+      .post('/pets')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ name: 'Noodle', species: 'Cat' })
+      .expect(201);
+
+    await request(app)
+      .put('/pets/' + pet.body.id)
+      .set('Authorization', 'Bearer ' + token)
+      .send({ status: 'adopted' })
+      .expect(200);
+
+    const feed = await request(app).get('/feed_events?limit=100').expect(200);
+    const events = Array.isArray(feed.body) ? feed.body : feed.body.items;
+    const match = events.find(function (e) {
+      return e.event_type === 'adoption_event' && e.pet_id === pet.body.id;
+    });
+
+    expect(match).toBeDefined();
+  });
+
+  it('updating a pet status to available emits a status_change event', async function () {
+    const { shelterId, token } = await createShelter();
+
+    const pet = await request(app)
+      .post('/pets')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ name: 'Pickles', species: 'Dog', status: 'pending' })
+      .expect(201);
+
+    await request(app)
+      .put('/pets/' + pet.body.id)
+      .set('Authorization', 'Bearer ' + token)
+      .send({ status: 'available' })
+      .expect(200);
+
+    const feed = await request(app).get('/feed_events?limit=100').expect(200);
+    const events = Array.isArray(feed.body) ? feed.body : feed.body.items;
+    const match = events.find(function (e) {
+      return e.event_type === 'status_change' && e.pet_id === pet.body.id;
+    });
+
+    expect(match).toBeDefined();
+  });
+
+  it('publishing a shelter post via POST emits a shelter_post event', async function () {
+    const { shelterId, token } = await createShelter();
+
+    const post = await request(app)
+      .post('/shelter-posts')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ shelter_id: shelterId, type: 'update', title: 'Big news', body: 'We have news.', publish: true })
+      .expect(201);
+
+    const feed = await request(app).get('/feed_events?limit=100').expect(200);
+    const events = Array.isArray(feed.body) ? feed.body : feed.body.items;
+    const match = events.find(function (e) {
+      return e.event_type === 'shelter_post' && e.shelter_id === shelterId;
+    });
+
+    expect(match).toBeDefined();
+  });
+
+  it('publishing a draft shelter post via PATCH emits a shelter_post event', async function () {
+    const { shelterId, token } = await createShelter();
+
+    const post = await request(app)
+      .post('/shelter-posts')
+      .set('Authorization', 'Bearer ' + token)
+      .send({ shelter_id: shelterId, type: 'update', title: 'Draft title', body: 'Draft body.' })
+      .expect(201);
+
+    await request(app)
+      .patch('/shelter-posts/' + post.body.id + '/publish')
+      .set('Authorization', 'Bearer ' + token)
+      .expect(200);
+
+    const feed = await request(app).get('/feed_events?limit=100').expect(200);
+    const events = Array.isArray(feed.body) ? feed.body : feed.body.items;
+    const match = events.find(function (e) {
+      return e.event_type === 'shelter_post' && e.shelter_id === shelterId;
+    });
+
+    expect(match).toBeDefined();
+  });
 });

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -32,40 +32,32 @@ export default function FeedPage() {
 
   const [filterType, setFilterType] = useState("all");
 
-  useEffect(() => {
-    let isAlive = true;
+  async function load() {
+    setStatus("loading");
+    setErrorMsg("");
 
-    async function load() {
-      setStatus("loading");
-      setErrorMsg("");
+    try {
+      const res = await fetch(`${API_BASE}/feed_events?limit=50`, {
+        credentials: "include",
+      });
 
-      try {
-        const res = await fetch(`${API_BASE}/feed_events?limit=50`, {
-          credentials: "include",
-        });
+      if (!res.ok) throw new Error(`Failed to load feed (${res.status})`);
 
-        if (!res.ok) throw new Error(`Failed to load feed (${res.status})`);
+      const data = await res.json();
 
-        const data = await res.json();
+      const rows = Array.isArray(data) ? data : (data.items ?? []);
+      const mapped = rows.map(mapRowToFeedItem);
 
-        const rows = Array.isArray(data) ? data : (data.items ?? []);
-        const mapped = rows.map(mapRowToFeedItem);
-
-        if (!isAlive) return;
-        setItems(mapped);
-        setStatus("ready");
-      } catch (err) {
-        if (!isAlive) return;
-        setErrorMsg(err?.message || "Unknown error");
-        setStatus("error");
-      }
-
+      setItems(mapped);
+      setStatus("ready");
+    } catch (err) {
+      setErrorMsg(err?.message || "Unknown error");
+      setStatus("error");
     }
+  }
 
+  useEffect(() => {
     load();
-    return () => {
-      isAlive = false;
-    };
   }, []);
 
   const visibleItems = useMemo(() => {
@@ -94,7 +86,7 @@ export default function FeedPage() {
             </select>
           </label>
 
-          <button className="btn" onClick={() => window.location.reload()}>
+          <button className="btn" onClick={load}>
             Refresh
           </button>
         </div>
@@ -112,7 +104,7 @@ export default function FeedPage() {
         <div className="card">
           <h2>Could not load feed</h2>
           <p className="muted">{errorMsg}</p>
-          <button className="btn" onClick={() => window.location.reload()}>
+          <button className="btn" onClick={load}>
             Retry
           </button>
         </div>


### PR DESCRIPTION
- Add createFeedEvent() to feed_events DAO
- Emit new_pet event when shelter admin creates a pet
- Emit adoption_event / status_change when pet status is updated to adopted / available
- Emit shelter_post event on publish (both POST with publish:true and PATCH publish)
- Add integration tests for all four feed event triggers
- Fix test runner: add --runInBand to prevent shared DB pool teardown race
- Fix feed page refresh button to reload data instead of full page reload
- Fix seed data to use correct event type names (new_pet, shelter_post)