### PR TITLE
Add delete and edit shelter posts with admin UI

### DIFF
--- a/backend/dao/shelter_posts.js
+++ b/backend/dao/shelter_posts.js
@@ -96,3 +96,39 @@ export async function publishShelterPost(postId) {
 
     return getShelterPostById(postId);
 }
+
+export async function updateShelterPost(postId, updates) {
+    const fields = [];
+    const params = [];
+
+    if (updates.title !== undefined) {
+        fields.push('title = ?');
+        params.push(updates.title);
+    }
+
+    if (updates.body !== undefined) {
+        fields.push('body = ?');
+        params.push(updates.body);
+    }
+
+    if (updates.type !== undefined) {
+        fields.push('type = ?');
+        params.push(updates.type);
+    }
+
+    if (fields.length === 0) return getShelterPostById(postId);
+
+    fields.push('updated_at = CURRENT_TIMESTAMP');
+    params.push(postId);
+
+    await db.query(
+        `UPDATE shelter_posts SET ${fields.join(', ')} WHERE id = ?`,
+        params
+    );
+
+    return getShelterPostById(postId);
+}
+
+export async function deleteShelterPost(postId) {
+    await db.query('DELETE FROM shelter_posts WHERE id = ?', [postId]);
+}

--- a/backend/routes/shelter_posts.js
+++ b/backend/routes/shelter_posts.js
@@ -4,7 +4,9 @@ import {
     createShelterPost,
     listShelterPosts,
     getShelterPostById,
-    publishShelterPost
+    publishShelterPost,
+    updateShelterPost,
+    deleteShelterPost
 } from '../dao/shelter_posts.js';
 import { getShelterByUserId } from '../dao/shelters.js';
 import { requireAuth, requireRole } from '../middleware/auth.js';
@@ -143,6 +145,64 @@ router.patch('/:id/publish', requireAuth, requireRole('shelter_admin'), asyncHan
     }
 
     res.json(updated);
+}));
+
+/**
+ * PATCH /api/shelter-posts/:id
+ * Edit a post's title, body, or type.
+ */
+router.patch('/:id', requireAuth, requireRole('shelter_admin'), asyncHandler(async function (req, res) {
+    const postId = req.params.id;
+
+    const shelter = await getShelterByUserId(req.userId);
+    if (!shelter) {
+        return res.status(404).json({ error: 'Shelter not found for user' });
+    }
+
+    const existing = await getShelterPostById(postId);
+    if (!existing) {
+        return res.status(404).json({ error: 'Post not found' });
+    }
+
+    if (existing.shelter_id !== shelter.id) {
+        return res.status(403).json({ error: 'Not allowed to edit this post' });
+    }
+
+    const updates = {};
+    if (typeof req.body.title === 'string') updates.title = req.body.title;
+    if (typeof req.body.body === 'string') updates.body = req.body.body;
+    if (typeof req.body.type === 'string') updates.type = req.body.type;
+
+    if (Object.keys(updates).length === 0) {
+        return res.status(400).json({ error: 'No valid fields provided to update' });
+    }
+
+    const updated = await updateShelterPost(postId, updates);
+    res.json(updated);
+}));
+
+/**
+ * DELETE /api/shelter-posts/:id
+ */
+router.delete('/:id', requireAuth, requireRole('shelter_admin'), asyncHandler(async function (req, res) {
+    const postId = req.params.id;
+
+    const shelter = await getShelterByUserId(req.userId);
+    if (!shelter) {
+        return res.status(404).json({ error: 'Shelter not found for user' });
+    }
+
+    const existing = await getShelterPostById(postId);
+    if (!existing) {
+        return res.status(404).json({ error: 'Post not found' });
+    }
+
+    if (existing.shelter_id !== shelter.id) {
+        return res.status(403).json({ error: 'Not allowed to delete this post' });
+    }
+
+    await deleteShelterPost(postId);
+    res.status(204).send();
 }));
 
 export default router;

--- a/backend/tests/shelter_posts.test.js
+++ b/backend/tests/shelter_posts.test.js
@@ -1,0 +1,119 @@
+import request from 'supertest';
+import app from '../main.js';
+import db from '../db/index.js';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+afterAll(async function () {
+    await db.end();
+});
+
+async function createShelterAdmin() {
+    const unique = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    const register = await request(app)
+        .post('/auth/register')
+        .send({ username: 'postadmin_' + unique, password: 'password123', role: 'shelter_admin' })
+        .expect(201);
+
+    const shelter = await request(app)
+        .post('/shelters')
+        .set('Authorization', 'Bearer ' + register.body.token)
+        .send({ name: 'Test Shelter ' + unique })
+        .expect(201);
+
+    return { token: register.body.token, shelterId: shelter.body.id };
+}
+
+async function createPost(token, shelterId, overrides = {}) {
+    const res = await request(app)
+        .post('/shelter-posts')
+        .set('Authorization', 'Bearer ' + token)
+        .send({ shelter_id: shelterId, type: 'update', title: 'Test Post', body: 'Test body.', ...overrides })
+        .expect(201);
+    return res.body;
+}
+
+describe('shelter_posts DELETE', function () {
+    it('deletes an owned post and returns 204', async function () {
+        const { token, shelterId } = await createShelterAdmin();
+        const post = await createPost(token, shelterId);
+
+        await request(app)
+            .delete('/shelter-posts/' + post.id)
+            .set('Authorization', 'Bearer ' + token)
+            .expect(204);
+
+        await request(app)
+            .get('/shelter-posts/' + post.id)
+            .expect(404);
+    });
+
+    it('returns 403 when another shelter admin tries to delete', async function () {
+        const { token, shelterId } = await createShelterAdmin();
+        const { token: otherToken } = await createShelterAdmin();
+        const post = await createPost(token, shelterId);
+
+        await request(app)
+            .delete('/shelter-posts/' + post.id)
+            .set('Authorization', 'Bearer ' + otherToken)
+            .expect(403);
+    });
+
+    it('returns 404 for a non-existent post', async function () {
+        const { token } = await createShelterAdmin();
+
+        await request(app)
+            .delete('/shelter-posts/non-existent-id')
+            .set('Authorization', 'Bearer ' + token)
+            .expect(404);
+    });
+});
+
+describe('shelter_posts PATCH (edit)', function () {
+    it('updates title and body of an owned post', async function () {
+        const { token, shelterId } = await createShelterAdmin();
+        const post = await createPost(token, shelterId);
+
+        const res = await request(app)
+            .patch('/shelter-posts/' + post.id)
+            .set('Authorization', 'Bearer ' + token)
+            .send({ title: 'Updated Title', body: 'Updated body.' })
+            .expect(200);
+
+        expect(res.body.title).toBe('Updated Title');
+        expect(res.body.body).toBe('Updated body.');
+    });
+
+    it('returns 403 when another shelter admin tries to edit', async function () {
+        const { token, shelterId } = await createShelterAdmin();
+        const { token: otherToken } = await createShelterAdmin();
+        const post = await createPost(token, shelterId);
+
+        await request(app)
+            .patch('/shelter-posts/' + post.id)
+            .set('Authorization', 'Bearer ' + otherToken)
+            .send({ title: 'Hacked title' })
+            .expect(403);
+    });
+
+    it('returns 400 when no valid fields are provided', async function () {
+        const { token, shelterId } = await createShelterAdmin();
+        const post = await createPost(token, shelterId);
+
+        await request(app)
+            .patch('/shelter-posts/' + post.id)
+            .set('Authorization', 'Bearer ' + token)
+            .send({})
+            .expect(400);
+    });
+
+    it('returns 404 for a non-existent post', async function () {
+        const { token } = await createShelterAdmin();
+
+        await request(app)
+            .patch('/shelter-posts/non-existent-id')
+            .set('Authorization', 'Bearer ' + token)
+            .send({ title: 'Whatever' })
+            .expect(404);
+    });
+});

--- a/frontend/src/pages/FeedPage.jsx
+++ b/frontend/src/pages/FeedPage.jsx
@@ -125,7 +125,7 @@ export default function FeedPage() {
               <option value="status_change">Status change</option>
               <option value="adoption_event">Adoption event</option>
               <option value="photo_added">Photo added</option>
-              <option value="update">Update</option>
+              <option value="shelter_post">Shelter post</option>
             </select>
           </label>
 

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -5,6 +5,7 @@ import * as AlertDialog from "@radix-ui/react-alert-dialog";
 import { getMyProfile } from "../services/users.js";
 import { deleteShelter } from "../services/shelters.js";
 import { updatePet } from "../services/pets.js";
+import { createShelterPost, listShelterPosts, updateShelterPost, deleteShelterPost, publishShelterPost } from "../services/shelter_posts.js";
 
 const STATUS_OPTIONS = ["available", "pending", "adopted"];
 const PET_PLACEHOLDER_BY_SPECIES = {
@@ -61,10 +62,90 @@ function Profile() {
   const [editingPetId, setEditingPetId] = useState(null);
   const [statusMessage, setStatusMessage] = useState("");
   const [statusError, setStatusError] = useState("");
+  const [posts, setPosts] = useState([]);
+  const [postsLoading, setPostsLoading] = useState(false);
+  const [editingPost, setEditingPost] = useState(null);
+  const [editDraft, setEditDraft] = useState({ title: "", body: "" });
+  const [editSaving, setEditSaving] = useState(false);
+  const [deletingPostId, setDeletingPostId] = useState(null);
+  const [publishingPostId, setPublishingPostId] = useState(null);
+  const [creatingPost, setCreatingPost] = useState(false);
+  const [newPostDraft, setNewPostDraft] = useState({ title: "", body: "", type: "update", publish: false });
+  const [newPostSaving, setNewPostSaving] = useState(false);
 
   useEffect(() => {
     fetchProfileData();
   }, []);
+
+  async function fetchPosts(shelterId) {
+    setPostsLoading(true);
+    try {
+      const result = await listShelterPosts({ shelterId });
+      setPosts(result.items || []);
+    } catch {
+      setPosts([]);
+    } finally {
+      setPostsLoading(false);
+    }
+  }
+
+  function openPostEditor(post) {
+    setEditingPost(post);
+    setEditDraft({ title: post.title, body: post.body });
+  }
+
+  async function handleSavePost() {
+    if (!editingPost) return;
+    setEditSaving(true);
+    try {
+      const updated = await updateShelterPost(editingPost.id, editDraft);
+      setPosts((prev) => prev.map((p) => p.id === updated.id ? updated : p));
+      setEditingPost(null);
+    } catch (err) {
+      alert("Failed to save: " + err.message);
+    } finally {
+      setEditSaving(false);
+    }
+  }
+
+  async function handleDeletePost(postId) {
+    setDeletingPostId(postId);
+    try {
+      await deleteShelterPost(postId);
+      setPosts((prev) => prev.filter((p) => p.id !== postId));
+    } catch (err) {
+      alert("Failed to delete: " + err.message);
+    } finally {
+      setDeletingPostId(null);
+    }
+  }
+
+  async function handlePublishPost(postId) {
+    setPublishingPostId(postId);
+    try {
+      const updated = await publishShelterPost(postId);
+      setPosts((prev) => prev.map((p) => p.id === updated.id ? updated : p));
+    } catch (err) {
+      alert("Failed to publish: " + err.message);
+    } finally {
+      setPublishingPostId(null);
+    }
+  }
+
+  async function handleCreatePost() {
+    if (!profile?.shelter?.id) return;
+    setNewPostSaving(true);
+    try {
+      const created = await createShelterPost({ shelterId: profile.shelter.id, ...newPostDraft });
+      setPosts((prev) => [created, ...prev]);
+      setCreatingPost(false);
+      setNewPostDraft({ title: "", body: "", type: "update", publish: false });
+    } catch (err) {
+      alert("Failed to create post: " + err.message);
+    } finally {
+      setNewPostSaving(false);
+    }
+  }
 
   async function fetchProfileData() {
     setLoading(true);
@@ -73,6 +154,9 @@ function Profile() {
       const data = await getMyProfile();
       setProfile(data);
       setPetStatusDrafts(buildPetStatusDrafts(data?.pets));
+      if (data?.shelter?.id) {
+        fetchPosts(data.shelter.id);
+      }
     } catch (err) {
       setError(err.message);
     } finally {
@@ -590,6 +674,226 @@ function Profile() {
     );
   }
 
+  function renderPostsTab() {
+    if (postsLoading) {
+      return <Text size="2" color="gray">Loading posts…</Text>;
+    }
+
+    return (
+      <Flex direction="column" gap="4">
+        <Card size="3">
+          <Flex justify="between" align="center">
+            <Heading size="5">Shelter Posts</Heading>
+            <Button onClick={() => setCreatingPost(true)}>New Post</Button>
+          </Flex>
+        </Card>
+
+        <Dialog.Root open={creatingPost} onOpenChange={(open) => { if (!open) setCreatingPost(false); }}>
+          <Dialog.Content maxWidth="520px">
+            <Dialog.Title>New Post</Dialog.Title>
+            <Flex direction="column" gap="4" mt="4">
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Type</Text>
+                <select
+                  value={newPostDraft.type}
+                  onChange={(e) => setNewPostDraft((d) => ({ ...d, type: e.target.value }))}
+                  style={{
+                    width: "100%", borderRadius: 10, border: "1px solid rgba(255,255,255,0.12)",
+                    background: "#2a2a2a", color: "#ffffff", padding: "10px 12px", font: "inherit"
+                  }}
+                >
+                  <option value="update" style={{ background: "#2a2a2a", color: "#fff" }}>Update</option>
+                  <option value="event" style={{ background: "#2a2a2a", color: "#fff" }}>Event</option>
+                  <option value="news" style={{ background: "#2a2a2a", color: "#fff" }}>News</option>
+                </select>
+              </label>
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Title</Text>
+                <input
+                  value={newPostDraft.title}
+                  onChange={(e) => setNewPostDraft((d) => ({ ...d, title: e.target.value }))}
+                  disabled={newPostSaving}
+                  style={{
+                    width: "100%", borderRadius: 10, border: "1px solid rgba(255,255,255,0.12)",
+                    background: "rgba(255,255,255,0.06)", color: "#e9eef5",
+                    padding: "10px 12px", font: "inherit", boxSizing: "border-box"
+                  }}
+                />
+              </label>
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Body</Text>
+                <textarea
+                  value={newPostDraft.body}
+                  onChange={(e) => setNewPostDraft((d) => ({ ...d, body: e.target.value }))}
+                  disabled={newPostSaving}
+                  rows={5}
+                  style={{
+                    width: "100%", borderRadius: 10, border: "1px solid rgba(255,255,255,0.12)",
+                    background: "rgba(255,255,255,0.06)", color: "#e9eef5",
+                    padding: "10px 12px", font: "inherit", resize: "vertical", boxSizing: "border-box"
+                  }}
+                />
+              </label>
+              <Flex align="center" gap="2">
+                <input
+                  type="checkbox"
+                  id="publish-now"
+                  checked={newPostDraft.publish}
+                  onChange={(e) => setNewPostDraft((d) => ({ ...d, publish: e.target.checked }))}
+                  disabled={newPostSaving}
+                />
+                <label htmlFor="publish-now">
+                  <Text size="2">Publish immediately</Text>
+                </label>
+              </Flex>
+              <Flex gap="3" justify="end">
+                <Button variant="soft" color="gray" onClick={() => setCreatingPost(false)} disabled={newPostSaving}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreatePost} disabled={newPostSaving || !newPostDraft.title || !newPostDraft.body}>
+                  {newPostSaving ? "Saving…" : "Create Post"}
+                </Button>
+              </Flex>
+            </Flex>
+          </Dialog.Content>
+        </Dialog.Root>
+
+        {posts.length === 0 ? (
+          <Card size="3" style={{ textAlign: "center" }}>
+            <Flex direction="column" gap="3" align="center">
+              <Heading size="5">No Posts Yet</Heading>
+              <Text size="2" color="gray">Posts you create will appear here.</Text>
+            </Flex>
+          </Card>
+        ) : (
+          posts.map((post) => (
+            <Card key={post.id} size="3">
+              <Flex direction="column" gap="2">
+                <Flex justify="between" align="start" gap="3">
+                  <Box style={{ flex: 1 }}>
+                    <Heading size="4">{post.title}</Heading>
+                    <Text size="1" color="gray">
+                      {post.published_at ? "Published " + new Date(post.published_at).toLocaleDateString() : "Draft"}
+                    </Text>
+                  </Box>
+                  <Flex gap="2" shrink="0">
+                    <Button size="2" variant="soft" onClick={() => openPostEditor(post)}>
+                      Edit
+                    </Button>
+                    {!post.published_at && (
+                      <Button size="2" variant="soft" color="green" onClick={() => handlePublishPost(post.id)} disabled={publishingPostId === post.id}>
+                        {publishingPostId === post.id ? "Publishing…" : "Publish"}
+                      </Button>
+                    )}
+                    <AlertDialog.Root>
+                      <AlertDialog.Trigger asChild>
+                        <Button size="2" color="red" variant="soft" disabled={deletingPostId === post.id}>
+                          {deletingPostId === post.id ? "Deleting…" : "Delete"}
+                        </Button>
+                      </AlertDialog.Trigger>
+                      <AlertDialog.Portal>
+                        <AlertDialog.Overlay style={{
+                          position: "fixed",
+                          inset: 0,
+                          background: "rgba(0, 0, 0, 0.5)",
+                          zIndex: 9998
+                        }} />
+                        <AlertDialog.Content style={{
+                          position: "fixed",
+                          top: "50%",
+                          left: "50%",
+                          transform: "translate(-50%, -50%)",
+                          width: "90%",
+                          maxWidth: "500px",
+                          background: "white",
+                          borderRadius: "12px",
+                          padding: "24px",
+                          boxShadow: "0 8px 32px rgba(0, 0, 0, 0.2)",
+                          zIndex: 9999
+                        }}>
+                          <AlertDialog.Title style={{
+                            fontSize: "1.25rem",
+                            fontWeight: 600,
+                            marginBottom: "12px",
+                            color: "#2d1810",
+                            display: "block"
+                          }}>
+                            Delete this post?
+                          </AlertDialog.Title>
+                          <AlertDialog.Description style={{
+                            fontSize: "0.95rem",
+                            color: "#5d3a2a",
+                            marginBottom: "24px",
+                            lineHeight: 1.6,
+                            display: "block"
+                          }}>
+                            This will permanently delete &ldquo;{post.title}&rdquo;. This action cannot be undone.
+                          </AlertDialog.Description>
+                          <div style={{ display: "flex", gap: "12px", justifyContent: "flex-end" }}>
+                            <AlertDialog.Cancel asChild>
+                              <Button variant="soft" color="gray" size="2">Cancel</Button>
+                            </AlertDialog.Cancel>
+                            <AlertDialog.Action asChild>
+                              <Button color="red" size="2" onClick={() => handleDeletePost(post.id)}>Delete</Button>
+                            </AlertDialog.Action>
+                          </div>
+                        </AlertDialog.Content>
+                      </AlertDialog.Portal>
+                    </AlertDialog.Root>
+                  </Flex>
+                </Flex>
+                <Text size="2" color="gray" style={{ whiteSpace: "pre-wrap" }}>{post.body}</Text>
+              </Flex>
+            </Card>
+          ))
+        )}
+
+        <Dialog.Root open={!!editingPost} onOpenChange={(open) => { if (!open) setEditingPost(null); }}>
+          <Dialog.Content maxWidth="520px">
+            <Dialog.Title>Edit Post</Dialog.Title>
+            <Flex direction="column" gap="4" mt="4">
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Title</Text>
+                <input
+                  value={editDraft.title}
+                  onChange={(e) => setEditDraft((d) => ({ ...d, title: e.target.value }))}
+                  disabled={editSaving}
+                  style={{
+                    width: "100%", borderRadius: 10, border: "1px solid rgba(255,255,255,0.12)",
+                    background: "rgba(255,255,255,0.06)", color: "#e9eef5",
+                    padding: "10px 12px", font: "inherit", boxSizing: "border-box"
+                  }}
+                />
+              </label>
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Body</Text>
+                <textarea
+                  value={editDraft.body}
+                  onChange={(e) => setEditDraft((d) => ({ ...d, body: e.target.value }))}
+                  disabled={editSaving}
+                  rows={6}
+                  style={{
+                    width: "100%", borderRadius: 10, border: "1px solid rgba(255,255,255,0.12)",
+                    background: "rgba(255,255,255,0.06)", color: "#e9eef5",
+                    padding: "10px 12px", font: "inherit", resize: "vertical", boxSizing: "border-box"
+                  }}
+                />
+              </label>
+              <Flex gap="3" justify="end">
+                <Button variant="soft" color="gray" onClick={() => setEditingPost(null)} disabled={editSaving}>
+                  Cancel
+                </Button>
+                <Button onClick={handleSavePost} disabled={editSaving || !editDraft.title || !editDraft.body}>
+                  {editSaving ? "Saving…" : "Save"}
+                </Button>
+              </Flex>
+            </Flex>
+          </Dialog.Content>
+        </Dialog.Root>
+      </Flex>
+    );
+  }
+
   if (loading) {
     return (
       <div style={{ maxWidth: "1100px", margin: "0 auto", padding: "48px 20px" }}>
@@ -636,10 +940,20 @@ function Profile() {
                 Pets
               </Button>
             )}
+            {profile.role === "shelter_admin" && (
+              <Button
+                variant={activeTab === "posts" ? "solid" : "soft"}
+                onClick={() => setActiveTab("posts")}
+              >
+                Posts
+              </Button>
+            )}
           </Flex>
         </Card>
 
-        {activeTab === "profile" ? renderOverviewTab() : renderPetsTab()}
+        {activeTab === "profile" && renderOverviewTab()}
+        {activeTab === "pets" && renderPetsTab()}
+        {activeTab === "posts" && renderPostsTab()}
       </Flex>
     </div>
   );

--- a/frontend/src/services/shelter_posts.js
+++ b/frontend/src/services/shelter_posts.js
@@ -1,0 +1,34 @@
+import { apiFetch } from "./api.js";
+
+export function createShelterPost({ shelterId, type, title, body, publish = false }) {
+  return apiFetch("/shelter-posts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ shelter_id: shelterId, type, title, body, publish }),
+  });
+}
+
+export function listShelterPosts({ shelterId, publishedOnly = false, limit = 50, offset = 0 } = {}) {
+  const params = new URLSearchParams();
+  if (shelterId) params.set("shelter_id", shelterId);
+  if (publishedOnly) params.set("published_only", "true");
+  params.set("limit", limit);
+  params.set("offset", offset);
+  return apiFetch(`/shelter-posts?${params}`);
+}
+
+export function updateShelterPost(postId, updates) {
+  return apiFetch(`/shelter-posts/${postId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(updates),
+  });
+}
+
+export function deleteShelterPost(postId) {
+  return apiFetch(`/shelter-posts/${postId}`, { method: "DELETE" });
+}
+
+export function publishShelterPost(postId) {
+  return apiFetch(`/shelter-posts/${postId}/publish`, { method: "PATCH" });
+}


### PR DESCRIPTION
- Add updateShelterPost and deleteShelterPost to DAO
- Add PATCH /:id (edit) and DELETE /:id routes with ownership checks
- Add 7 tests covering delete, edit, 403, and 404 cases
- Add Posts tab to admin profile with create, edit, publish, and delete
- Add shelter_posts frontend service
- Fix feed filter "Update" option to correctly match shelter_post event type