### PR TITLE
Linpatr/recommendations queue

### DIFF
--- a/backend/dao/index.js
+++ b/backend/dao/index.js
@@ -12,3 +12,9 @@ export {
 } from './shelter_posts.js';
 export { listRecentActivity } from './feed_events.js';
 export { getEmailNotifications, updateEmailNotifications } from './email_notifications.js';
+export {
+    createPetInteraction,
+    getUserPetPreferences,
+    listRecommendedPets,
+    upsertUserPetPreferences
+} from './recommendations.js';

--- a/backend/dao/recommendations.js
+++ b/backend/dao/recommendations.js
@@ -1,0 +1,176 @@
+import crypto from 'node:crypto';
+import db from '../db/index.js';
+
+const ARRAY_FIELDS = ['species', 'breeds', 'sex', 'sizes'];
+
+function parseJsonArray(value) {
+    if (value === null || value === undefined) return [];
+    if (Array.isArray(value)) return value;
+    try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+function mapPreferenceRow(row) {
+    if (!row) return null;
+
+    const mapped = { ...row };
+    ARRAY_FIELDS.forEach(function (field) {
+        mapped[field] = parseJsonArray(mapped[field]);
+    });
+    return mapped;
+}
+
+export async function getUserPetPreferences(userId) {
+    const result = await db.query(
+        `SELECT user_id, species, breeds, sex, sizes, min_age_years, max_age_years,
+                city, state, postal_code, radius_miles, created_at, updated_at
+         FROM user_pet_preferences
+         WHERE user_id = ?`,
+        [userId]
+    );
+
+    return mapPreferenceRow(result.rows[0] || null);
+}
+
+export async function upsertUserPetPreferences(userId, preferences) {
+    const species = preferences.species ? JSON.stringify(preferences.species) : null;
+    const breeds = preferences.breeds ? JSON.stringify(preferences.breeds) : null;
+    const sex = preferences.sex ? JSON.stringify(preferences.sex) : null;
+    const sizes = preferences.sizes ? JSON.stringify(preferences.sizes) : null;
+
+    await db.query(
+        `INSERT INTO user_pet_preferences
+            (user_id, species, breeds, sex, sizes, min_age_years, max_age_years, city, state, postal_code, radius_miles)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON DUPLICATE KEY UPDATE
+            species = VALUES(species),
+            breeds = VALUES(breeds),
+            sex = VALUES(sex),
+            sizes = VALUES(sizes),
+            min_age_years = VALUES(min_age_years),
+            max_age_years = VALUES(max_age_years),
+            city = VALUES(city),
+            state = VALUES(state),
+            postal_code = VALUES(postal_code),
+            radius_miles = VALUES(radius_miles),
+            updated_at = CURRENT_TIMESTAMP`,
+        [
+            userId,
+            species,
+            breeds,
+            sex,
+            sizes,
+            preferences.min_age_years ?? null,
+            preferences.max_age_years ?? null,
+            preferences.city || null,
+            preferences.state || null,
+            preferences.postal_code || null,
+            preferences.radius_miles ?? 50
+        ]
+    );
+
+    return getUserPetPreferences(userId);
+}
+
+export async function createPetInteraction(userId, petId, interactionType) {
+    const id = crypto.randomUUID();
+    await db.query(
+        `INSERT IGNORE INTO pet_interactions (id, user_id, pet_id, interaction_type)
+         VALUES (?, ?, ?, ?)`,
+        [id, userId, petId, interactionType]
+    );
+}
+
+export async function listRecommendedPets(userId, preferences = {}, limit = 20) {
+    const safeLimit = Math.max(1, Math.min(Number(limit) || 20, 50));
+    const filters = [
+        `p.status = 'available'`,
+        `NOT EXISTS (
+            SELECT 1
+            FROM pet_interactions pi
+            WHERE pi.user_id = ?
+              AND pi.pet_id = p.id
+              AND pi.interaction_type IN ('liked', 'passed')
+        )`
+    ];
+    const params = [userId];
+
+    function addInFilter(column, values) {
+        if (!Array.isArray(values) || values.length === 0) return;
+        const cleanValues = values.filter(function (value) {
+            return typeof value === 'string' && value.trim();
+        });
+        if (cleanValues.length === 0) return;
+
+        filters.push(`${column} IN (${cleanValues.map(() => '?').join(', ')})`);
+        params.push(...cleanValues);
+    }
+
+    addInFilter('p.species', preferences.species);
+    addInFilter('p.breed', preferences.breeds);
+    addInFilter('p.sex', preferences.sex);
+    addInFilter('p.size', preferences.sizes);
+
+    if (preferences.min_age_years !== null && preferences.min_age_years !== undefined) {
+        filters.push('p.age_years >= ?');
+        params.push(Number(preferences.min_age_years));
+    }
+
+    if (preferences.max_age_years !== null && preferences.max_age_years !== undefined) {
+        filters.push('p.age_years <= ?');
+        params.push(Number(preferences.max_age_years));
+    }
+
+    if (preferences.postal_code) {
+        filters.push('s.postal_code = ?');
+        params.push(preferences.postal_code);
+    } else {
+        if (preferences.city) {
+            filters.push('s.city = ?');
+            params.push(preferences.city);
+        }
+        if (preferences.state) {
+            filters.push('s.state = ?');
+            params.push(preferences.state);
+        }
+    }
+
+    params.push(safeLimit);
+
+    const result = await db.query(
+        `SELECT
+            p.id,
+            p.shelter_id,
+            s.name AS shelter_name,
+            s.city AS shelter_city,
+            s.state AS shelter_state,
+            s.postal_code AS shelter_postal_code,
+            p.name,
+            p.species,
+            p.breed,
+            p.age_years,
+            p.sex,
+            p.size,
+            p.description,
+            p.status,
+            (SELECT url FROM pet_photos WHERE pet_id = p.id ORDER BY created_at DESC LIMIT 1) AS primary_photo_url,
+            (SELECT COUNT(*) FROM pet_interactions WHERE pet_id = p.id AND interaction_type = 'liked') AS liked_count,
+            (SELECT COUNT(*) FROM pet_interactions WHERE pet_id = p.id AND interaction_type = 'passed') AS passed_count,
+            (SELECT COUNT(*) FROM pet_interactions WHERE pet_id = p.id AND interaction_type = 'shown') AS shown_count
+         FROM pets p
+         JOIN shelters s ON s.id = p.shelter_id
+         WHERE ${filters.join(' AND ')}
+         ORDER BY
+            ((SELECT COUNT(*) FROM pet_interactions WHERE pet_id = p.id AND interaction_type = 'liked') * 2
+             - (SELECT COUNT(*) FROM pet_interactions WHERE pet_id = p.id AND interaction_type = 'passed')) DESC,
+            p.created_at DESC
+         LIMIT ?`,
+        params
+    );
+
+    return result.rows;
+}

--- a/backend/db/schema.sql
+++ b/backend/db/schema.sql
@@ -131,3 +131,40 @@ CREATE TABLE IF NOT EXISTS favorites (
         REFERENCES pets (id)
         ON DELETE CASCADE
 )  ENGINE=INNODB DEFAULT CHARSET=UTF8MB4;
+
+CREATE TABLE IF NOT EXISTS user_pet_preferences (
+    user_id CHAR(36) PRIMARY KEY,
+    species JSON DEFAULT NULL,
+    breeds JSON DEFAULT NULL,
+    sex JSON DEFAULT NULL,
+    sizes JSON DEFAULT NULL,
+    min_age_years INT DEFAULT NULL,
+    max_age_years INT DEFAULT NULL,
+    city VARCHAR(255) DEFAULT NULL,
+    state VARCHAR(100) DEFAULT NULL,
+    postal_code VARCHAR(20) DEFAULT NULL,
+    radius_miles INT NOT NULL DEFAULT 50,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT NULL,
+    CONSTRAINT user_pet_preferences_user_fk FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE
+) ENGINE=INNODB DEFAULT CHARSET=UTF8MB4;
+
+CREATE TABLE IF NOT EXISTS pet_interactions (
+    id CHAR(36) PRIMARY KEY DEFAULT (UUID()),
+    user_id CHAR(36) NOT NULL,
+    pet_id CHAR(36) NOT NULL,
+    interaction_type ENUM('shown', 'viewed', 'liked', 'passed') NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pet_interactions_user_fk FOREIGN KEY (user_id)
+        REFERENCES users (id)
+        ON DELETE CASCADE,
+    CONSTRAINT pet_interactions_pet_fk FOREIGN KEY (pet_id)
+        REFERENCES pets (id)
+        ON DELETE CASCADE,
+    UNIQUE KEY pet_interactions_user_pet_type_unique (user_id, pet_id, interaction_type),
+    INDEX pet_interactions_user_pet_idx (user_id, pet_id),
+    INDEX pet_interactions_pet_type_idx (pet_id, interaction_type),
+    INDEX pet_interactions_user_type_idx (user_id, interaction_type)
+) ENGINE=INNODB DEFAULT CHARSET=UTF8MB4;

--- a/backend/main.js
+++ b/backend/main.js
@@ -15,6 +15,7 @@ import shelterFollowsRoutes from './routes/shelter_follows.js';
 import shelterPostsRoutes from './routes/shelter_posts.js';
 import feedEventsRoutes from './routes/feed_events.js';
 import emailNotificationsRoutes from './routes/email_notifications.js';
+import recommendationsRoutes from './routes/recommendations.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -55,6 +56,7 @@ app.use('/favorites', favoritesRoutes);
 app.use('/shelter-follows', shelterFollowsRoutes);
 app.use('/shelter-posts', shelterPostsRoutes);
 app.use('/feed_events', feedEventsRoutes);
+app.use('/recommendations', recommendationsRoutes);
 
 // Preferences & notifications
 app.use('/email-notifications', emailNotificationsRoutes);

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "prestart": "node ./scripts/generate_swagger.js",
+    "db:schema": "node ./scripts/apply_schema.js",
     "swagger": "node ./scripts/generate_swagger.js",
     "test": "node ./scripts/run_tests.js",
     "start": "node main.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "prestart": "node ./scripts/generate_swagger.js",
     "db:schema": "node ./scripts/apply_schema.js",
+    "seed:recommendations": "node ./scripts/seed_recommendations_demo.js",
     "swagger": "node ./scripts/generate_swagger.js",
     "test": "node ./scripts/run_tests.js",
     "start": "node main.js"

--- a/backend/routes/recommendations.js
+++ b/backend/routes/recommendations.js
@@ -1,0 +1,66 @@
+import express from 'express';
+import asyncHandler from '../utils/async-handler.js';
+import { requireAuth, requireRole } from '../middleware/auth.js';
+import { getPetById } from '../dao/pets.js';
+import {
+    getRecommendationPreferences,
+    getRecommendationQueue,
+    recordRecommendationInteraction,
+    updateRecommendationPreferences
+} from '../services/recommendations.js';
+
+const router = express.Router();
+
+function handleServiceError(err, res) {
+    if (err.status) {
+        return res.status(err.status).json({ error: err.message });
+    }
+    throw err;
+}
+
+router.get('/preferences', requireAuth, requireRole('adopter'), asyncHandler(async function (req, res) {
+    const preferences = await getRecommendationPreferences(req.userId);
+    res.json(preferences);
+}));
+
+router.patch('/preferences', requireAuth, requireRole('adopter'), asyncHandler(async function (req, res) {
+    try {
+        const preferences = await updateRecommendationPreferences(req.userId, req.body || {});
+        res.json(preferences);
+    } catch (err) {
+        return handleServiceError(err, res);
+    }
+}));
+
+router.get('/queue', requireAuth, requireRole('adopter'), asyncHandler(async function (req, res) {
+    const result = await getRecommendationQueue(req.userId, req.query.limit);
+    res.json({
+        items: result.items,
+        preferences: result.preferences,
+        limit: Math.max(1, Math.min(Number(req.query.limit) || 20, 50))
+    });
+}));
+
+router.post('/interactions', requireAuth, requireRole('adopter'), asyncHandler(async function (req, res) {
+    const petId = req.body.pet_id;
+    const interactionType = req.body.interaction_type;
+
+    if (!petId) {
+        return res.status(400).json({ error: 'pet_id is required' });
+    }
+
+    const pet = await getPetById(petId);
+    if (!pet) {
+        return res.status(404).json({ error: 'Pet not found' });
+    }
+
+    try {
+        await recordRecommendationInteraction(req.userId, petId, interactionType);
+    } catch (err) {
+        return handleServiceError(err, res);
+    }
+
+    res.status(204).end();
+}));
+
+export default router;

--- a/backend/scripts/apply_schema.js
+++ b/backend/scripts/apply_schema.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+'use strict';
+
+import dotenv from 'dotenv';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import mysql from 'mysql2/promise';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.join(__dirname, '..', '.env') });
+
+export async function applySchema(databaseUrl = process.env.DATABASE_URL) {
+    if (!databaseUrl) {
+        throw new Error('DATABASE_URL is required');
+    }
+
+    const url = new URL(databaseUrl);
+    const dbName = url.pathname.replace(/^\//, '');
+    if (!dbName) {
+        throw new Error('DATABASE_URL must include a database name');
+    }
+
+    const schemaPath = path.join(__dirname, '..', 'db', 'schema.sql');
+    const schemaSql = await fs.readFile(schemaPath, 'utf8');
+
+    if (!schemaSql.trim()) {
+        return;
+    }
+
+    const connection = await mysql.createConnection({
+        host: url.hostname || 'localhost',
+        port: url.port ? Number(url.port) : 3306,
+        user: url.username || 'root',
+        password: url.password || '',
+        database: dbName,
+        multipleStatements: true
+    });
+
+    try {
+        await connection.query(schemaSql);
+    } finally {
+        await connection.end();
+    }
+}
+
+async function main() {
+    await applySchema();
+    console.log('Database schema applied.');
+}
+
+const isMain = process.argv[1] && path.resolve(process.argv[1]) === __filename;
+
+if (isMain) {
+    main().catch(function (err) {
+        console.error(err.message);
+        process.exit(1);
+    });
+}

--- a/backend/scripts/seed_recommendations_demo.js
+++ b/backend/scripts/seed_recommendations_demo.js
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+'use strict';
+
+import 'dotenv/config';
+import bcrypt from 'bcryptjs';
+import crypto from 'node:crypto';
+import db from '../db/index.js';
+
+const PETS_PER_SHELTER = Number(process.env.RECOMMENDATION_PETS_PER_SHELTER || 25);
+const PASSWORD = process.env.RECOMMENDATION_SEED_PASSWORD || 'password123';
+
+const STATES = [
+    ['AL', 'Birmingham', '35203'], ['AK', 'Anchorage', '99501'], ['AZ', 'Phoenix', '85001'],
+    ['AR', 'Little Rock', '72201'], ['CA', 'Sacramento', '95814'], ['CO', 'Denver', '80202'],
+    ['CT', 'Hartford', '06103'], ['DE', 'Wilmington', '19801'], ['FL', 'Orlando', '32801'],
+    ['GA', 'Atlanta', '30303'], ['HI', 'Honolulu', '96813'], ['ID', 'Boise', '83702'],
+    ['IL', 'Chicago', '60601'], ['IN', 'Indianapolis', '46204'], ['IA', 'Des Moines', '50309'],
+    ['KS', 'Wichita', '67202'], ['KY', 'Louisville', '40202'], ['LA', 'New Orleans', '70112'],
+    ['ME', 'Portland', '04101'], ['MD', 'Baltimore', '21201'], ['MA', 'Boston', '02108'],
+    ['MI', 'Detroit', '48226'], ['MN', 'Minneapolis', '55401'], ['MS', 'Jackson', '39201'],
+    ['MO', 'Kansas City', '64106'], ['MT', 'Billings', '59101'], ['NE', 'Omaha', '68102'],
+    ['NV', 'Reno', '89501'], ['NH', 'Manchester', '03101'], ['NJ', 'Newark', '07102'],
+    ['NM', 'Albuquerque', '87102'], ['NY', 'Albany', '12207'], ['NC', 'Charlotte', '28202'],
+    ['ND', 'Fargo', '58102'], ['OH', 'Columbus', '43215'], ['OK', 'Oklahoma City', '73102'],
+    ['OR', 'Corvallis', '97330'], ['PA', 'Philadelphia', '19103'], ['RI', 'Providence', '02903'],
+    ['SC', 'Charleston', '29401'], ['SD', 'Sioux Falls', '57104'], ['TN', 'Nashville', '37203'],
+    ['TX', 'Austin', '78701'], ['UT', 'Salt Lake City', '84101'], ['VT', 'Burlington', '05401'],
+    ['VA', 'Richmond', '23219'], ['WA', 'Seattle', '98101'], ['WV', 'Charleston', '25301'],
+    ['WI', 'Madison', '53703'], ['WY', 'Cheyenne', '82001']
+];
+
+const DOG_BREEDS = ['Labrador Mix', 'Golden Retriever', 'German Shepherd', 'Beagle', 'Poodle Mix', 'Husky'];
+const CAT_BREEDS = ['Domestic Shorthair', 'Tabby', 'Calico', 'Siamese Mix', 'Maine Coon Mix', 'Tuxedo'];
+const OTHER_PETS = [
+    ['Rabbit', 'Holland Lop'],
+    ['Rabbit', 'Mini Rex'],
+    ['Bird', 'Cockatiel'],
+    ['Bird', 'Parakeet']
+];
+const NAMES = [
+    'Milo', 'Luna', 'Charlie', 'Bella', 'Cooper', 'Daisy', 'Finn', 'Ruby', 'Scout', 'Willow',
+    'Jasper', 'Nala', 'Murphy', 'Penny', 'Atlas', 'Olive', 'Theo', 'Cleo', 'Winston', 'Hazel',
+    'Remi', 'Poppy', 'Moose', 'Ivy', 'Archie'
+];
+const SIZES = ['Small', 'Medium', 'Large', 'XL'];
+
+function uuid() {
+    return crypto.randomUUID();
+}
+
+function pickByIndex(values, index) {
+    return values[index % values.length];
+}
+
+async function findUserByUsername(username) {
+    const result = await db.query('SELECT * FROM users WHERE username = ?', [username]);
+    return result.rows[0] || null;
+}
+
+async function ensureUser({ username, role }) {
+    const existing = await findUserByUsername(username);
+    if (existing) return existing;
+
+    const id = uuid();
+    const passwordHash = await bcrypt.hash(PASSWORD, 10);
+
+    await db.query(
+        'INSERT INTO users (id, username, password_hash, role) VALUES (?, ?, ?, ?)',
+        [id, username, passwordHash, role]
+    );
+    await db.query('INSERT IGNORE INTO email_notifications (user_id) VALUES (?)', [id]);
+
+    const result = await db.query('SELECT * FROM users WHERE id = ?', [id]);
+    return result.rows[0];
+}
+
+async function ensureShelter({ userId, name, city, state, postalCode }) {
+    const existing = await db.query('SELECT * FROM shelters WHERE user_id = ?', [userId]);
+    if (existing.rows[0]) return existing.rows[0];
+
+    const id = uuid();
+    await db.query(
+        `INSERT INTO shelters
+            (id, user_id, name, description, phone, email, city, state, postal_code)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+            id,
+            userId,
+            name,
+            `Demo shelter for recommendation testing in ${city}, ${state}.`,
+            `555-${state.charCodeAt(0)}${state.charCodeAt(1)}${String(city.length).padStart(2, '0')}`,
+            `contact@${state.toLowerCase()}-pawmatch-demo.test`,
+            city,
+            state,
+            postalCode
+        ]
+    );
+
+    const result = await db.query('SELECT * FROM shelters WHERE id = ?', [id]);
+    return result.rows[0];
+}
+
+function buildPet(state, city, index) {
+    let species;
+    let breed;
+
+    if (index % 5 === 0) {
+        const other = pickByIndex(OTHER_PETS, index);
+        species = other[0];
+        breed = other[1];
+    } else if (index % 2 === 0) {
+        species = 'Cat';
+        breed = pickByIndex(CAT_BREEDS, index);
+    } else {
+        species = 'Dog';
+        breed = pickByIndex(DOG_BREEDS, index);
+    }
+
+    const name = `${pickByIndex(NAMES, index)} ${state}`;
+    const status = index % 17 === 0 ? 'pending' : 'available';
+
+    return {
+        name,
+        species,
+        breed,
+        age_years: index % 14,
+        sex: index % 2 === 0 ? 'F' : 'M',
+        size: species === 'Dog' ? pickByIndex(SIZES, index) : pickByIndex(['Small', 'Medium'], index),
+        status,
+        description: `${name} is a ${breed} in ${city}, ${state}, seeded for recommendation queue demos.`
+    };
+}
+
+async function ensurePet(shelterId, pet) {
+    const existing = await db.query(
+        'SELECT id FROM pets WHERE shelter_id = ? AND name = ?',
+        [shelterId, pet.name]
+    );
+    if (existing.rows[0]) return existing.rows[0].id;
+
+    const id = uuid();
+    await db.query(
+        `INSERT INTO pets (id, shelter_id, name, species, breed, age_years, sex, size, description, status)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [id, shelterId, pet.name, pet.species, pet.breed, pet.age_years, pet.sex, pet.size, pet.description, pet.status]
+    );
+
+    const text = encodeURIComponent(`${pet.species}: ${pet.name}`);
+    await db.query(
+        'INSERT INTO pet_photos (id, pet_id, url) VALUES (?, ?, ?)',
+        [uuid(), id, `https://placehold.co/600x450/e8f3ef/2d3a36?text=${text}`]
+    );
+
+    return id;
+}
+
+async function seedAdopters() {
+    const adopters = [
+        {
+            username: 'demo_adopter_or',
+            preferences: { species: ['Dog'], sizes: ['Medium', 'Large'], state: 'OR', radius_miles: 50 }
+        },
+        {
+            username: 'demo_adopter_tx',
+            preferences: { species: ['Cat', 'Dog'], state: 'TX', radius_miles: 50 }
+        },
+        {
+            username: 'demo_adopter_any',
+            preferences: { species: [], state: null, radius_miles: 500 }
+        }
+    ];
+
+    for (const adopter of adopters) {
+        const user = await ensureUser({ username: adopter.username, role: 'adopter' });
+        await db.query(
+            `INSERT INTO user_pet_preferences
+                (user_id, species, breeds, sex, sizes, min_age_years, max_age_years, city, state, postal_code, radius_miles)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             ON DUPLICATE KEY UPDATE
+                species = VALUES(species),
+                breeds = VALUES(breeds),
+                sex = VALUES(sex),
+                sizes = VALUES(sizes),
+                city = VALUES(city),
+                state = VALUES(state),
+                postal_code = VALUES(postal_code),
+                radius_miles = VALUES(radius_miles),
+                updated_at = CURRENT_TIMESTAMP`,
+            [
+                user.id,
+                JSON.stringify(adopter.preferences.species || []),
+                JSON.stringify([]),
+                JSON.stringify([]),
+                JSON.stringify(adopter.preferences.sizes || []),
+                null,
+                null,
+                null,
+                adopter.preferences.state,
+                null,
+                adopter.preferences.radius_miles
+            ]
+        );
+    }
+}
+
+async function main() {
+    console.log(`Seeding recommendation demo data: ${STATES.length} shelters, ${PETS_PER_SHELTER} pets per shelter.`);
+    console.log(`Demo account password: ${PASSWORD}`);
+
+    for (const [state, city, postalCode] of STATES) {
+        const username = `demo_shelter_${state.toLowerCase()}`;
+        const user = await ensureUser({ username, role: 'shelter_admin' });
+        const shelter = await ensureShelter({
+            userId: user.id,
+            name: `${state} PawMatch Demo Shelter`,
+            city,
+            state,
+            postalCode
+        });
+
+        for (let i = 0; i < PETS_PER_SHELTER; i++) {
+            await ensurePet(shelter.id, buildPet(state, city, i));
+        }
+
+        process.stdout.write('.');
+    }
+
+    await seedAdopters();
+    console.log('\nRecommendation demo seed complete.');
+    await db.end();
+}
+
+main().catch(function (err) {
+    console.error(err);
+    process.exit(1);
+});

--- a/backend/services/recommendations.js
+++ b/backend/services/recommendations.js
@@ -1,0 +1,122 @@
+import {
+    createPetInteraction,
+    getUserPetPreferences,
+    listRecommendedPets,
+    upsertUserPetPreferences
+} from '../dao/recommendations.js';
+import { addFavorite } from '../dao/favorites.js';
+
+export const ALLOWED_INTERACTION_TYPES = ['shown', 'viewed', 'liked', 'passed'];
+
+const DEFAULT_PREFERENCES = {
+    species: [],
+    breeds: [],
+    sex: [],
+    sizes: [],
+    min_age_years: null,
+    max_age_years: null,
+    city: null,
+    state: null,
+    postal_code: null,
+    radius_miles: 50
+};
+
+function cleanString(value) {
+    if (typeof value !== 'string') return null;
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+}
+
+function cleanStringArray(value) {
+    if (!Array.isArray(value)) return undefined;
+
+    return Array.from(new Set(value
+        .filter(function (item) {
+            return typeof item === 'string' && item.trim();
+        })
+        .map(function (item) {
+            return item.trim();
+        })))
+        .slice(0, 25);
+}
+
+function cleanInteger(value) {
+    if (value === null) return null;
+    if (value === undefined || value === '') return undefined;
+
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 0) return undefined;
+    return parsed;
+}
+
+export function defaultRecommendationPreferences() {
+    return { ...DEFAULT_PREFERENCES };
+}
+
+export async function getRecommendationPreferences(userId) {
+    const existing = await getUserPetPreferences(userId);
+    return { ...DEFAULT_PREFERENCES, ...(existing || {}) };
+}
+
+export async function updateRecommendationPreferences(userId, body) {
+    const existing = await getRecommendationPreferences(userId);
+    const next = { ...existing };
+    let changed = false;
+
+    ['species', 'breeds', 'sex', 'sizes'].forEach(function (field) {
+        const cleaned = cleanStringArray(body[field]);
+        if (cleaned !== undefined) {
+            next[field] = cleaned;
+            changed = true;
+        }
+    });
+
+    ['city', 'state', 'postal_code'].forEach(function (field) {
+        if (Object.prototype.hasOwnProperty.call(body, field)) {
+            next[field] = cleanString(body[field]);
+            changed = true;
+        }
+    });
+
+    ['min_age_years', 'max_age_years', 'radius_miles'].forEach(function (field) {
+        const cleaned = cleanInteger(body[field]);
+        if (cleaned !== undefined) {
+            next[field] = cleaned;
+            changed = true;
+        }
+    });
+
+    if (next.min_age_years !== null && next.max_age_years !== null && next.min_age_years > next.max_age_years) {
+        const err = new Error('min_age_years cannot be greater than max_age_years');
+        err.status = 400;
+        throw err;
+    }
+
+    if (!changed) {
+        const err = new Error('No valid preference fields provided');
+        err.status = 400;
+        throw err;
+    }
+
+    return upsertUserPetPreferences(userId, next);
+}
+
+export async function getRecommendationQueue(userId, limit) {
+    const preferences = await getRecommendationPreferences(userId);
+    const items = await listRecommendedPets(userId, preferences, limit);
+    return { preferences, items };
+}
+
+export async function recordRecommendationInteraction(userId, petId, interactionType) {
+    if (!ALLOWED_INTERACTION_TYPES.includes(interactionType)) {
+        const err = new Error('Invalid interaction_type');
+        err.status = 400;
+        throw err;
+    }
+
+    await createPetInteraction(userId, petId, interactionType);
+
+    if (interactionType === 'liked') {
+        await addFavorite(userId, petId);
+    }
+}

--- a/backend/tests/recommendations.test.js
+++ b/backend/tests/recommendations.test.js
@@ -1,0 +1,152 @@
+import request from 'supertest';
+import app from '../main.js';
+import db from '../db/index.js';
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret';
+
+afterAll(async function () {
+    await db.end();
+});
+
+async function registerUser(role) {
+    const unique = Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
+    const res = await request(app)
+        .post('/auth/register')
+        .send({ username: `recommend_${role}_${unique}`, password: 'password123', role })
+        .expect(201);
+    return res.body.token;
+}
+
+async function createShelterWithPet({ shelterName, city = 'Corvallis', state = 'OR', postalCode = '97330', pet }) {
+    const adminToken = await registerUser('shelter_admin');
+
+    const shelterRes = await request(app)
+        .post('/shelters')
+        .set('Authorization', 'Bearer ' + adminToken)
+        .send({ name: shelterName, city, state, postal_code: postalCode })
+        .expect(201);
+
+    const petRes = await request(app)
+        .post('/pets')
+        .set('Authorization', 'Bearer ' + adminToken)
+        .send(pet)
+        .expect(201);
+
+    return { shelter: shelterRes.body, pet: petRes.body };
+}
+
+describe('recommendations', function () {
+    it('returns default preferences for an adopter', async function () {
+        const adopterToken = await registerUser('adopter');
+
+        const res = await request(app)
+            .get('/recommendations/preferences')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .expect(200);
+
+        expect(res.body.species).toEqual([]);
+        expect(res.body.radius_miles).toBe(50);
+    });
+
+    it('saves and returns adopter queue preferences', async function () {
+        const adopterToken = await registerUser('adopter');
+
+        const res = await request(app)
+            .patch('/recommendations/preferences')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .send({
+                species: ['Dog'],
+                sizes: ['Medium'],
+                min_age_years: 1,
+                max_age_years: 6,
+                state: 'OR',
+                radius_miles: 25
+            })
+            .expect(200);
+
+        expect(res.body.species).toEqual(['Dog']);
+        expect(res.body.sizes).toEqual(['Medium']);
+        expect(res.body.state).toBe('OR');
+        expect(res.body.radius_miles).toBe(25);
+    });
+
+    it('returns matching available pets and excludes passed pets', async function () {
+        const adopterToken = await registerUser('adopter');
+        const matching = await createShelterWithPet({
+            shelterName: 'Recommendation Oregon Shelter',
+            city: 'Corvallis',
+            state: 'OR',
+            pet: { name: 'Queue Match', species: 'Dog', breed: 'Lab Mix', age_years: 3, sex: 'M', size: 'Medium' }
+        });
+        await createShelterWithPet({
+            shelterName: 'Recommendation Washington Shelter',
+            city: 'Seattle',
+            state: 'WA',
+            pet: { name: 'Queue Far Away', species: 'Dog', breed: 'Lab Mix', age_years: 3, sex: 'M', size: 'Medium' }
+        });
+        await createShelterWithPet({
+            shelterName: 'Recommendation Cat Shelter',
+            city: 'Corvallis',
+            state: 'OR',
+            pet: { name: 'Queue Cat', species: 'Cat', breed: 'Tabby', age_years: 3, sex: 'F', size: 'Small' }
+        });
+
+        await request(app)
+            .patch('/recommendations/preferences')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .send({ species: ['Dog'], state: 'OR' })
+            .expect(200);
+
+        const firstQueue = await request(app)
+            .get('/recommendations/queue?limit=10')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .expect(200);
+
+        expect(firstQueue.body.items.some((pet) => pet.id === matching.pet.id)).toBe(true);
+        expect(firstQueue.body.items.every((pet) => pet.species === 'Dog')).toBe(true);
+        expect(firstQueue.body.items.every((pet) => pet.shelter_state === 'OR')).toBe(true);
+
+        await request(app)
+            .post('/recommendations/interactions')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .send({ pet_id: matching.pet.id, interaction_type: 'passed' })
+            .expect(204);
+
+        const secondQueue = await request(app)
+            .get('/recommendations/queue?limit=10')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .expect(200);
+
+        expect(secondQueue.body.items.some((pet) => pet.id === matching.pet.id)).toBe(false);
+    });
+
+    it('records liked interactions as favorites', async function () {
+        const adopterToken = await registerUser('adopter');
+        const created = await createShelterWithPet({
+            shelterName: 'Recommendation Like Shelter',
+            pet: { name: 'Queue Like', species: 'Dog', breed: 'Lab Mix', age_years: 2, sex: 'F', size: 'Small' }
+        });
+
+        await request(app)
+            .post('/recommendations/interactions')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .send({ pet_id: created.pet.id, interaction_type: 'liked' })
+            .expect(204);
+
+        const favorites = await request(app)
+            .get('/favorites')
+            .set('Authorization', 'Bearer ' + adopterToken)
+            .expect(200);
+
+        expect(favorites.body.some((favorite) => favorite.pet_id === created.pet.id)).toBe(true);
+    });
+
+    it('rejects shelter admins from recommendation endpoints', async function () {
+        const adminToken = await registerUser('shelter_admin');
+
+        await request(app)
+            .get('/recommendations/queue')
+            .set('Authorization', 'Bearer ' + adminToken)
+            .expect(403);
+    });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,7 @@ import SetupShelter from './pages/SetupShelter.jsx'
 import Navbar from './components/Navbar.jsx'
 import BrowseAllPets from "./pages/BrowseAllPets.jsx";
 import Favorites from "./pages/Favorites.jsx";
+import Discover from "./pages/Discover.jsx";
 import './App.css'
 import { Link, Routes, Route, Navigate, useLocation } from "react-router-dom"
 import { useAuth } from "./auth/useAuth.js"
@@ -140,6 +141,7 @@ function App() {
         <Route path="/setup-shelter" element={<RequireRole role="shelter_admin"><SetupShelter /></RequireRole>} />
         <Route path="/create-pet" element={<RequireRole role="shelter_admin"><CreatePet /></RequireRole>} />
         <Route path="/find-and-browse" element={<RequireAuth><Navigate to="/browse-pets" replace /></RequireAuth>} />
+        <Route path="/discover" element={<RequireAuth><Discover /></RequireAuth>} />
         <Route path="/pet-finder" element={<RequireAuth><PetFinder/></RequireAuth>} />
         <Route path="/browse-pets" element={<RequireAuth><BrowseAllPets /></RequireAuth>} />
         <Route path="/browse-shelters" element={<RequireAuth><BrowseShelters /></RequireAuth>} />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -100,6 +100,16 @@ function Navbar() {
               {!isShelterAdmin && (
                 <NavigationMenu.Item>
                   <NavigationMenu.Link asChild>
+                    <Link to="/discover" style={navLinkStyle('/discover')}>
+                      Discover
+                    </Link>
+                  </NavigationMenu.Link>
+                </NavigationMenu.Item>
+              )}
+
+              {!isShelterAdmin && (
+                <NavigationMenu.Item>
+                  <NavigationMenu.Link asChild>
                     <Link to="/favorites" style={navLinkStyle('/favorites')}>
                       Favorites
                     </Link>

--- a/frontend/src/pages/Discover.jsx
+++ b/frontend/src/pages/Discover.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { Button, Card, Flex, Heading, Text } from "@radix-ui/themes";
+import { Button, Card, Dialog, Flex, Heading, Text } from "@radix-ui/themes";
 import {
   getRecommendationPreferences,
   getRecommendationQueue,
@@ -69,11 +69,14 @@ function toPayload(preferences) {
 
 export default function Discover() {
   const [preferences, setPreferences] = useState(emptyPreferences);
+  const [draftPreferences, setDraftPreferences] = useState(emptyPreferences);
   const [queue, setQueue] = useState([]);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [queueLoading, setQueueLoading] = useState(false);
   const [saving, setSaving] = useState(false);
   const [acting, setActing] = useState(false);
+  const [filtersOpen, setFiltersOpen] = useState(false);
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
 
@@ -98,7 +101,9 @@ export default function Discover() {
         ]);
 
         if (!active) return;
-        setPreferences(normalizePreferences(savedPreferences));
+        const normalized = normalizePreferences(savedPreferences);
+        setPreferences(normalized);
+        setDraftPreferences(normalized);
         setQueue(Array.isArray(queueResult?.items) ? queueResult.items : []);
         setCurrentIndex(0);
       } catch (err) {
@@ -117,24 +122,39 @@ export default function Discover() {
   }, []);
 
   async function refreshQueue() {
-    const result = await getRecommendationQueue({ limit: 20 });
-    setQueue(Array.isArray(result?.items) ? result.items : []);
-    setCurrentIndex(0);
+    try {
+      setQueueLoading(true);
+      setError("");
+      const result = await getRecommendationQueue({ limit: 20 });
+      setQueue(Array.isArray(result?.items) ? result.items : []);
+      setCurrentIndex(0);
+    } catch (err) {
+      setError(err?.message || "Failed to refresh recommendations.");
+    } finally {
+      setQueueLoading(false);
+    }
   }
 
   async function handleSavePreferences() {
     try {
       setSaving(true);
+      setQueueLoading(true);
+      setFiltersOpen(false);
       setError("");
       setMessage("");
-      const updated = await updateRecommendationPreferences(toPayload(preferences));
-      setPreferences(normalizePreferences(updated));
-      await refreshQueue();
+      const updated = await updateRecommendationPreferences(toPayload(draftPreferences));
+      const normalized = normalizePreferences(updated);
+      setPreferences(normalized);
+      setDraftPreferences(normalized);
+      const result = await getRecommendationQueue({ limit: 20 });
+      setQueue(Array.isArray(result?.items) ? result.items : []);
+      setCurrentIndex(0);
       setMessage("Preferences saved.");
     } catch (err) {
       setError(err?.message || "Failed to save preferences.");
     } finally {
       setSaving(false);
+      setQueueLoading(false);
     }
   }
 
@@ -159,11 +179,18 @@ export default function Discover() {
   }
 
   function setArrayPreference(field, value) {
-    setPreferences((current) => ({
+    setDraftPreferences((current) => ({
       ...current,
       [field]: toggleValue(current[field], value),
     }));
   }
+
+  function openFilters() {
+    setDraftPreferences(preferences);
+    setFiltersOpen(true);
+  }
+
+  const cardBusy = loading || queueLoading || saving;
 
   return (
     <div style={{ maxWidth: 1100, margin: "0 auto", padding: "40px 20px" }}>
@@ -173,148 +200,82 @@ export default function Discover() {
             <Heading size="7">Discover Pets</Heading>
             <Text size="2" color="gray">Queue based on your saved filters and location.</Text>
           </div>
-          <Button variant="soft" onClick={refreshQueue} disabled={loading || saving || acting}>
-            Refresh
-          </Button>
+          <Flex gap="2" wrap="wrap">
+            <Button variant="soft" onClick={openFilters} disabled={loading || saving || acting}>
+              Filters
+            </Button>
+            <Button variant="soft" onClick={refreshQueue} disabled={loading || queueLoading || saving || acting}>
+              {queueLoading ? "Refreshing..." : "Refresh"}
+            </Button>
+          </Flex>
         </Flex>
 
         {error && <Text size="2" color="red">{error}</Text>}
         {message && <Text size="2" color="green">{message}</Text>}
 
-        <div
-          style={{
-            display: "grid",
-            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-            gap: 18,
-            alignItems: "start",
-          }}
-        >
-          <Card size="3">
-            <Flex direction="column" gap="4">
-              <Heading size="4">Filters</Heading>
+        <Dialog.Root open={filtersOpen} onOpenChange={(open) => {
+          if (!saving) setFiltersOpen(open);
+        }}>
+          <Dialog.Content maxWidth="560px">
+            <Dialog.Title>Discover Filters</Dialog.Title>
+            <Dialog.Description size="2" color="gray">
+              Save your preferences to rebuild the recommendation queue.
+            </Dialog.Description>
 
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="bold">Species</Text>
-                <Flex gap="2" wrap="wrap">
-                  {SPECIES_OPTIONS.map((option) => (
-                    <Button
-                      key={option}
-                      size="1"
-                      variant={optionButtonVariant(preferences.species, option)}
-                      onClick={() => setArrayPreference("species", option)}
-                    >
-                      {option}
-                    </Button>
-                  ))}
-                </Flex>
+            <Flex direction="column" gap="4" mt="4">
+              {renderFilterControls({
+                preferences: draftPreferences,
+                setPreferences: setDraftPreferences,
+                setArrayPreference,
+                saving,
+              })}
+
+              <Flex gap="3" justify="end">
+                <Button
+                  variant="soft"
+                  color="gray"
+                  onClick={() => {
+                    setDraftPreferences(preferences);
+                    setFiltersOpen(false);
+                  }}
+                  disabled={saving}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={handleSavePreferences} disabled={saving || loading}>
+                  {saving ? "Saving..." : "Save filters"}
+                </Button>
               </Flex>
-
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="bold">Size</Text>
-                <Flex gap="2" wrap="wrap">
-                  {SIZE_OPTIONS.map((option) => (
-                    <Button
-                      key={option}
-                      size="1"
-                      variant={optionButtonVariant(preferences.sizes, option)}
-                      onClick={() => setArrayPreference("sizes", option)}
-                    >
-                      {option}
-                    </Button>
-                  ))}
-                </Flex>
-              </Flex>
-
-              <Flex direction="column" gap="2">
-                <Text size="2" weight="bold">Sex</Text>
-                <Flex gap="2" wrap="wrap">
-                  {SEX_OPTIONS.map((option) => (
-                    <Button
-                      key={option}
-                      size="1"
-                      variant={optionButtonVariant(preferences.sex, option)}
-                      onClick={() => setArrayPreference("sex", option)}
-                    >
-                      {option}
-                    </Button>
-                  ))}
-                </Flex>
-              </Flex>
-
-              <Flex gap="2">
-                <label style={{ flex: 1 }}>
-                  <Text as="div" size="2" mb="1" weight="bold">Min age</Text>
-                  <input
-                    type="number"
-                    min="0"
-                    value={preferences.min_age_years}
-                    onChange={(e) => setPreferences((current) => ({ ...current, min_age_years: e.target.value }))}
-                    style={inputStyle}
-                  />
-                </label>
-                <label style={{ flex: 1 }}>
-                  <Text as="div" size="2" mb="1" weight="bold">Max age</Text>
-                  <input
-                    type="number"
-                    min="0"
-                    value={preferences.max_age_years}
-                    onChange={(e) => setPreferences((current) => ({ ...current, max_age_years: e.target.value }))}
-                    style={inputStyle}
-                  />
-                </label>
-              </Flex>
-
-              <Flex gap="2">
-                <label style={{ flex: 1 }}>
-                  <Text as="div" size="2" mb="1" weight="bold">City</Text>
-                  <input
-                    value={preferences.city}
-                    onChange={(e) => setPreferences((current) => ({ ...current, city: e.target.value }))}
-                    style={inputStyle}
-                  />
-                </label>
-                <label style={{ width: 88 }}>
-                  <Text as="div" size="2" mb="1" weight="bold">State</Text>
-                  <input
-                    value={preferences.state}
-                    onChange={(e) => setPreferences((current) => ({ ...current, state: e.target.value.toUpperCase() }))}
-                    maxLength={2}
-                    style={inputStyle}
-                  />
-                </label>
-              </Flex>
-
-              <label>
-                <Text as="div" size="2" mb="1" weight="bold">Postal code</Text>
-                <input
-                  value={preferences.postal_code}
-                  onChange={(e) => setPreferences((current) => ({ ...current, postal_code: e.target.value }))}
-                  style={inputStyle}
-                />
-              </label>
-
-              <Button onClick={handleSavePreferences} disabled={saving || loading}>
-                {saving ? "Saving..." : "Save filters"}
-              </Button>
             </Flex>
-          </Card>
+          </Dialog.Content>
+        </Dialog.Root>
 
-          <Flex direction="column" align="center" gap="3">
+        <Flex direction="column" align="center" gap="3">
             <Text size="2" color="gray">
-              {loading ? "Loading queue..." : `${remainingCount} pets in queue for ${locationLabel}`}
+              {cardBusy ? "Loading queue..." : `${remainingCount} pets in queue for ${locationLabel}`}
             </Text>
 
-            {!loading && !currentPet && (
-              <Card size="3" style={{ width: "100%", maxWidth: 520, textAlign: "center" }}>
-                <Flex direction="column" gap="3" align="center">
-                  <Heading size="5">No Matches Right Now</Heading>
-                  <Text size="2" color="gray">Try widening your filters or checking back after shelters add more pets.</Text>
-                  <Button variant="soft" onClick={handleSavePreferences}>Update queue</Button>
+            {cardBusy && (
+              <Card size="3" style={{ width: "100%", maxWidth: 520, minHeight: 420 }}>
+                <Flex direction="column" justify="center" align="center" gap="3" style={{ minHeight: 380 }}>
+                  <div style={spinnerStyle} />
+                  <Heading size="5">Building your queue</Heading>
+                  <Text size="2" color="gray">Finding the best pets for your filters.</Text>
                 </Flex>
               </Card>
             )}
 
-            {!loading && currentPet && (
+            {!cardBusy && !currentPet && (
+              <Card size="3" style={{ width: "100%", maxWidth: 520, textAlign: "center" }}>
+                <Flex direction="column" gap="3" align="center">
+                  <Heading size="5">No Matches Right Now</Heading>
+                  <Text size="2" color="gray">Try widening your filters or checking back after shelters add more pets.</Text>
+                  <Button variant="soft" onClick={openFilters}>Adjust filters</Button>
+                </Flex>
+              </Card>
+            )}
+
+            {!cardBusy && currentPet && (
               <Card size="3" style={{ width: "100%", maxWidth: 520 }}>
                 <Flex direction="column" gap="3">
                   {currentPet.primary_photo_url && (
@@ -366,10 +327,123 @@ export default function Discover() {
                 </Flex>
               </Card>
             )}
-          </Flex>
-        </div>
+        </Flex>
       </Flex>
     </div>
+  );
+}
+
+function renderFilterControls({ preferences, setPreferences, setArrayPreference, saving }) {
+  return (
+    <>
+      <Flex direction="column" gap="2">
+        <Text size="2" weight="bold">Species</Text>
+        <Flex gap="2" wrap="wrap">
+          {SPECIES_OPTIONS.map((option) => (
+            <Button
+              key={option}
+              size="1"
+              variant={optionButtonVariant(preferences.species, option)}
+              onClick={() => setArrayPreference("species", option)}
+              disabled={saving}
+            >
+              {option}
+            </Button>
+          ))}
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="2">
+        <Text size="2" weight="bold">Size</Text>
+        <Flex gap="2" wrap="wrap">
+          {SIZE_OPTIONS.map((option) => (
+            <Button
+              key={option}
+              size="1"
+              variant={optionButtonVariant(preferences.sizes, option)}
+              onClick={() => setArrayPreference("sizes", option)}
+              disabled={saving}
+            >
+              {option}
+            </Button>
+          ))}
+        </Flex>
+      </Flex>
+
+      <Flex direction="column" gap="2">
+        <Text size="2" weight="bold">Sex</Text>
+        <Flex gap="2" wrap="wrap">
+          {SEX_OPTIONS.map((option) => (
+            <Button
+              key={option}
+              size="1"
+              variant={optionButtonVariant(preferences.sex, option)}
+              onClick={() => setArrayPreference("sex", option)}
+              disabled={saving}
+            >
+              {option}
+            </Button>
+          ))}
+        </Flex>
+      </Flex>
+
+      <Flex gap="2">
+        <label style={{ flex: 1 }}>
+          <Text as="div" size="2" mb="1" weight="bold">Min age</Text>
+          <input
+            type="number"
+            min="0"
+            value={preferences.min_age_years}
+            onChange={(e) => setPreferences((current) => ({ ...current, min_age_years: e.target.value }))}
+            disabled={saving}
+            style={inputStyle}
+          />
+        </label>
+        <label style={{ flex: 1 }}>
+          <Text as="div" size="2" mb="1" weight="bold">Max age</Text>
+          <input
+            type="number"
+            min="0"
+            value={preferences.max_age_years}
+            onChange={(e) => setPreferences((current) => ({ ...current, max_age_years: e.target.value }))}
+            disabled={saving}
+            style={inputStyle}
+          />
+        </label>
+      </Flex>
+
+      <Flex gap="2">
+        <label style={{ flex: 1 }}>
+          <Text as="div" size="2" mb="1" weight="bold">City</Text>
+          <input
+            value={preferences.city}
+            onChange={(e) => setPreferences((current) => ({ ...current, city: e.target.value }))}
+            disabled={saving}
+            style={inputStyle}
+          />
+        </label>
+        <label style={{ width: 88 }}>
+          <Text as="div" size="2" mb="1" weight="bold">State</Text>
+          <input
+            value={preferences.state}
+            onChange={(e) => setPreferences((current) => ({ ...current, state: e.target.value.toUpperCase() }))}
+            maxLength={2}
+            disabled={saving}
+            style={inputStyle}
+          />
+        </label>
+      </Flex>
+
+      <label>
+        <Text as="div" size="2" mb="1" weight="bold">Postal code</Text>
+        <input
+          value={preferences.postal_code}
+          onChange={(e) => setPreferences((current) => ({ ...current, postal_code: e.target.value }))}
+          disabled={saving}
+          style={inputStyle}
+        />
+      </label>
+    </>
   );
 }
 
@@ -382,4 +456,13 @@ const inputStyle = {
   color: "#fff",
   padding: "9px 10px",
   font: "inherit",
+};
+
+const spinnerStyle = {
+  width: 34,
+  height: 34,
+  borderRadius: "50%",
+  border: "3px solid rgba(255, 255, 255, 0.18)",
+  borderTopColor: "#ffffff",
+  animation: "ui-spinner-rotate 0.8s linear infinite",
 };

--- a/frontend/src/pages/Discover.jsx
+++ b/frontend/src/pages/Discover.jsx
@@ -278,18 +278,29 @@ export default function Discover() {
             {!cardBusy && currentPet && (
               <Card size="3" style={{ width: "100%", maxWidth: 520 }}>
                 <Flex direction="column" gap="3">
-                  {currentPet.primary_photo_url && (
-                    <img
-                      src={currentPet.primary_photo_url}
-                      alt={currentPet.name}
-                      style={{
-                        width: "100%",
-                        aspectRatio: "4 / 3",
-                        objectFit: "cover",
-                        borderRadius: 8,
-                      }}
-                    />
-                  )}
+                  <div style={photoFrameStyle}>
+                    {acting ? (
+                      <Flex direction="column" align="center" justify="center" gap="3" style={{ minHeight: "100%" }}>
+                        <div style={spinnerStyle} />
+                        <Text size="2" color="gray">Saving your choice...</Text>
+                      </Flex>
+                    ) : currentPet.primary_photo_url ? (
+                      <img
+                        src={currentPet.primary_photo_url}
+                        alt={currentPet.name}
+                        style={{
+                          width: "100%",
+                          height: "100%",
+                          objectFit: "cover",
+                          display: "block",
+                        }}
+                      />
+                    ) : (
+                      <Flex align="center" justify="center" style={{ minHeight: "100%" }}>
+                        <Text size="2" color="gray">Photo coming soon</Text>
+                      </Flex>
+                    )}
+                  </div>
 
                   <Flex justify="between" align="start" gap="3">
                     <div>
@@ -456,6 +467,15 @@ const inputStyle = {
   color: "#fff",
   padding: "9px 10px",
   font: "inherit",
+};
+
+const photoFrameStyle = {
+  width: "100%",
+  aspectRatio: "4 / 3",
+  overflow: "hidden",
+  borderRadius: 8,
+  background: "rgba(255, 255, 255, 0.06)",
+  border: "1px solid rgba(255, 255, 255, 0.1)",
 };
 
 const spinnerStyle = {

--- a/frontend/src/pages/Discover.jsx
+++ b/frontend/src/pages/Discover.jsx
@@ -1,0 +1,385 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link } from "react-router-dom";
+import { Button, Card, Flex, Heading, Text } from "@radix-ui/themes";
+import {
+  getRecommendationPreferences,
+  getRecommendationQueue,
+  recordRecommendationInteraction,
+  updateRecommendationPreferences,
+} from "../services/recommendations.js";
+
+const SPECIES_OPTIONS = ["Dog", "Cat", "Rabbit", "Bird"];
+const SIZE_OPTIONS = ["Small", "Medium", "Large", "XL"];
+const SEX_OPTIONS = ["M", "F"];
+
+const emptyPreferences = {
+  species: [],
+  breeds: [],
+  sex: [],
+  sizes: [],
+  min_age_years: "",
+  max_age_years: "",
+  city: "",
+  state: "",
+  postal_code: "",
+  radius_miles: 50,
+};
+
+function normalizePreferences(preferences) {
+  return {
+    ...emptyPreferences,
+    ...preferences,
+    species: Array.isArray(preferences?.species) ? preferences.species : [],
+    breeds: Array.isArray(preferences?.breeds) ? preferences.breeds : [],
+    sex: Array.isArray(preferences?.sex) ? preferences.sex : [],
+    sizes: Array.isArray(preferences?.sizes) ? preferences.sizes : [],
+    min_age_years: preferences?.min_age_years ?? "",
+    max_age_years: preferences?.max_age_years ?? "",
+    city: preferences?.city || "",
+    state: preferences?.state || "",
+    postal_code: preferences?.postal_code || "",
+    radius_miles: preferences?.radius_miles ?? 50,
+  };
+}
+
+function toggleValue(values, value) {
+  return values.includes(value)
+    ? values.filter((item) => item !== value)
+    : [...values, value];
+}
+
+function optionButtonVariant(values, value) {
+  return values.includes(value) ? "solid" : "soft";
+}
+
+function toPayload(preferences) {
+  return {
+    species: preferences.species,
+    breeds: preferences.breeds,
+    sex: preferences.sex,
+    sizes: preferences.sizes,
+    min_age_years: preferences.min_age_years === "" ? null : Number(preferences.min_age_years),
+    max_age_years: preferences.max_age_years === "" ? null : Number(preferences.max_age_years),
+    city: preferences.city,
+    state: preferences.state,
+    postal_code: preferences.postal_code,
+    radius_miles: Number(preferences.radius_miles) || 50,
+  };
+}
+
+export default function Discover() {
+  const [preferences, setPreferences] = useState(emptyPreferences);
+  const [queue, setQueue] = useState([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [acting, setActing] = useState(false);
+  const [message, setMessage] = useState("");
+  const [error, setError] = useState("");
+
+  const currentPet = queue[currentIndex] || null;
+  const remainingCount = Math.max(queue.length - currentIndex, 0);
+
+  const locationLabel = useMemo(() => {
+    const parts = [preferences.city, preferences.state, preferences.postal_code].filter(Boolean);
+    return parts.length ? parts.join(", ") : "Any location";
+  }, [preferences.city, preferences.state, preferences.postal_code]);
+
+  useEffect(() => {
+    let active = true;
+
+    async function loadDiscoverData() {
+      try {
+        setLoading(true);
+        setError("");
+        const [savedPreferences, queueResult] = await Promise.all([
+          getRecommendationPreferences(),
+          getRecommendationQueue({ limit: 20 }),
+        ]);
+
+        if (!active) return;
+        setPreferences(normalizePreferences(savedPreferences));
+        setQueue(Array.isArray(queueResult?.items) ? queueResult.items : []);
+        setCurrentIndex(0);
+      } catch (err) {
+        if (!active) return;
+        setError(err?.message || "Failed to load recommendations.");
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadDiscoverData();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  async function refreshQueue() {
+    const result = await getRecommendationQueue({ limit: 20 });
+    setQueue(Array.isArray(result?.items) ? result.items : []);
+    setCurrentIndex(0);
+  }
+
+  async function handleSavePreferences() {
+    try {
+      setSaving(true);
+      setError("");
+      setMessage("");
+      const updated = await updateRecommendationPreferences(toPayload(preferences));
+      setPreferences(normalizePreferences(updated));
+      await refreshQueue();
+      setMessage("Preferences saved.");
+    } catch (err) {
+      setError(err?.message || "Failed to save preferences.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleInteraction(interactionType) {
+    if (!currentPet) return;
+
+    try {
+      setActing(true);
+      setError("");
+      await recordRecommendationInteraction({ petId: currentPet.id, interactionType });
+      setCurrentIndex((index) => index + 1);
+      if (interactionType === "liked") {
+        setMessage(`${currentPet.name} was added to your favorites.`);
+      } else {
+        setMessage("");
+      }
+    } catch (err) {
+      setError(err?.message || "Failed to save your choice.");
+    } finally {
+      setActing(false);
+    }
+  }
+
+  function setArrayPreference(field, value) {
+    setPreferences((current) => ({
+      ...current,
+      [field]: toggleValue(current[field], value),
+    }));
+  }
+
+  return (
+    <div style={{ maxWidth: 1100, margin: "0 auto", padding: "40px 20px" }}>
+      <Flex direction="column" gap="4">
+        <Flex direction={{ initial: "column", sm: "row" }} justify="between" align={{ initial: "start", sm: "center" }} gap="3">
+          <div>
+            <Heading size="7">Discover Pets</Heading>
+            <Text size="2" color="gray">Queue based on your saved filters and location.</Text>
+          </div>
+          <Button variant="soft" onClick={refreshQueue} disabled={loading || saving || acting}>
+            Refresh
+          </Button>
+        </Flex>
+
+        {error && <Text size="2" color="red">{error}</Text>}
+        {message && <Text size="2" color="green">{message}</Text>}
+
+        <div
+          style={{
+            display: "grid",
+            gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+            gap: 18,
+            alignItems: "start",
+          }}
+        >
+          <Card size="3">
+            <Flex direction="column" gap="4">
+              <Heading size="4">Filters</Heading>
+
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="bold">Species</Text>
+                <Flex gap="2" wrap="wrap">
+                  {SPECIES_OPTIONS.map((option) => (
+                    <Button
+                      key={option}
+                      size="1"
+                      variant={optionButtonVariant(preferences.species, option)}
+                      onClick={() => setArrayPreference("species", option)}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                </Flex>
+              </Flex>
+
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="bold">Size</Text>
+                <Flex gap="2" wrap="wrap">
+                  {SIZE_OPTIONS.map((option) => (
+                    <Button
+                      key={option}
+                      size="1"
+                      variant={optionButtonVariant(preferences.sizes, option)}
+                      onClick={() => setArrayPreference("sizes", option)}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                </Flex>
+              </Flex>
+
+              <Flex direction="column" gap="2">
+                <Text size="2" weight="bold">Sex</Text>
+                <Flex gap="2" wrap="wrap">
+                  {SEX_OPTIONS.map((option) => (
+                    <Button
+                      key={option}
+                      size="1"
+                      variant={optionButtonVariant(preferences.sex, option)}
+                      onClick={() => setArrayPreference("sex", option)}
+                    >
+                      {option}
+                    </Button>
+                  ))}
+                </Flex>
+              </Flex>
+
+              <Flex gap="2">
+                <label style={{ flex: 1 }}>
+                  <Text as="div" size="2" mb="1" weight="bold">Min age</Text>
+                  <input
+                    type="number"
+                    min="0"
+                    value={preferences.min_age_years}
+                    onChange={(e) => setPreferences((current) => ({ ...current, min_age_years: e.target.value }))}
+                    style={inputStyle}
+                  />
+                </label>
+                <label style={{ flex: 1 }}>
+                  <Text as="div" size="2" mb="1" weight="bold">Max age</Text>
+                  <input
+                    type="number"
+                    min="0"
+                    value={preferences.max_age_years}
+                    onChange={(e) => setPreferences((current) => ({ ...current, max_age_years: e.target.value }))}
+                    style={inputStyle}
+                  />
+                </label>
+              </Flex>
+
+              <Flex gap="2">
+                <label style={{ flex: 1 }}>
+                  <Text as="div" size="2" mb="1" weight="bold">City</Text>
+                  <input
+                    value={preferences.city}
+                    onChange={(e) => setPreferences((current) => ({ ...current, city: e.target.value }))}
+                    style={inputStyle}
+                  />
+                </label>
+                <label style={{ width: 88 }}>
+                  <Text as="div" size="2" mb="1" weight="bold">State</Text>
+                  <input
+                    value={preferences.state}
+                    onChange={(e) => setPreferences((current) => ({ ...current, state: e.target.value.toUpperCase() }))}
+                    maxLength={2}
+                    style={inputStyle}
+                  />
+                </label>
+              </Flex>
+
+              <label>
+                <Text as="div" size="2" mb="1" weight="bold">Postal code</Text>
+                <input
+                  value={preferences.postal_code}
+                  onChange={(e) => setPreferences((current) => ({ ...current, postal_code: e.target.value }))}
+                  style={inputStyle}
+                />
+              </label>
+
+              <Button onClick={handleSavePreferences} disabled={saving || loading}>
+                {saving ? "Saving..." : "Save filters"}
+              </Button>
+            </Flex>
+          </Card>
+
+          <Flex direction="column" align="center" gap="3">
+            <Text size="2" color="gray">
+              {loading ? "Loading queue..." : `${remainingCount} pets in queue for ${locationLabel}`}
+            </Text>
+
+            {!loading && !currentPet && (
+              <Card size="3" style={{ width: "100%", maxWidth: 520, textAlign: "center" }}>
+                <Flex direction="column" gap="3" align="center">
+                  <Heading size="5">No Matches Right Now</Heading>
+                  <Text size="2" color="gray">Try widening your filters or checking back after shelters add more pets.</Text>
+                  <Button variant="soft" onClick={handleSavePreferences}>Update queue</Button>
+                </Flex>
+              </Card>
+            )}
+
+            {!loading && currentPet && (
+              <Card size="3" style={{ width: "100%", maxWidth: 520 }}>
+                <Flex direction="column" gap="3">
+                  {currentPet.primary_photo_url && (
+                    <img
+                      src={currentPet.primary_photo_url}
+                      alt={currentPet.name}
+                      style={{
+                        width: "100%",
+                        aspectRatio: "4 / 3",
+                        objectFit: "cover",
+                        borderRadius: 8,
+                      }}
+                    />
+                  )}
+
+                  <Flex justify="between" align="start" gap="3">
+                    <div>
+                      <Heading size="6">{currentPet.name}</Heading>
+                      <Text size="2" color="gray">
+                        {currentPet.species || "Unknown"} / {currentPet.breed || "Unknown breed"}
+                      </Text>
+                    </div>
+                    <Text size="2" color="gray">
+                      {currentIndex + 1}/{queue.length}
+                    </Text>
+                  </Flex>
+
+                  <Text size="2" color="gray">
+                    Age: {currentPet.age_years ?? "?"} / Size: {currentPet.size || "?"} / Sex: {currentPet.sex || "?"}
+                  </Text>
+                  <Text size="2" color="gray">
+                    {currentPet.shelter_name} {currentPet.shelter_city ? `- ${currentPet.shelter_city}, ${currentPet.shelter_state || ""}` : ""}
+                  </Text>
+                  {currentPet.description && (
+                    <Text size="2" style={{ lineHeight: 1.6 }}>{currentPet.description}</Text>
+                  )}
+
+                  <Flex gap="3" justify="center" wrap="wrap">
+                    <Button size="3" variant="soft" color="gray" disabled={acting} onClick={() => handleInteraction("passed")}>
+                      Pass
+                    </Button>
+                    <Button size="3" disabled={acting} onClick={() => handleInteraction("liked")}>
+                      Like
+                    </Button>
+                    <Button size="3" variant="soft" asChild>
+                      <Link to={`/pets/${currentPet.id}`}>Details</Link>
+                    </Button>
+                  </Flex>
+                </Flex>
+              </Card>
+            )}
+          </Flex>
+        </div>
+      </Flex>
+    </div>
+  );
+}
+
+const inputStyle = {
+  width: "100%",
+  boxSizing: "border-box",
+  borderRadius: 8,
+  border: "1px solid rgba(255, 255, 255, 0.18)",
+  background: "rgba(255, 255, 255, 0.06)",
+  color: "#fff",
+  padding: "9px 10px",
+  font: "inherit",
+};

--- a/frontend/src/services/recommendations.js
+++ b/frontend/src/services/recommendations.js
@@ -1,0 +1,25 @@
+import { apiFetch } from "./api.js";
+
+export function getRecommendationPreferences() {
+  return apiFetch("/recommendations/preferences");
+}
+
+export function updateRecommendationPreferences(preferences) {
+  return apiFetch("/recommendations/preferences", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(preferences),
+  });
+}
+
+export function getRecommendationQueue({ limit = 20 } = {}) {
+  return apiFetch(`/recommendations/queue?limit=${limit}`);
+}
+
+export function recordRecommendationInteraction({ petId, interactionType }) {
+  return apiFetch("/recommendations/interactions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ pet_id: petId, interaction_type: interactionType }),
+  });
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -23,6 +23,7 @@ export default defineConfig({
       '/shelter-follows': 'http://localhost:4516',
       '/shelter-posts': 'http://localhost:4516',
       '/email-notifications': 'http://localhost:4516',
+      '/recommendations': 'http://localhost:4516',
       '/api': 'http://localhost:4516'
     }
   }


### PR DESCRIPTION
- Add recommendation queue backend with adopter preferences, pet interactions, queue filtering, and Like/Pass tracking.
- Add `/recommendations` API endpoints for preferences, queue retrieval, and interaction recording; liked pets are also added to favorites.
- Add Discover page with real backend-powered recommendation cards, Like/Pass/Details actions, filters modal, and loading states.
- Add non-destructive schema apply script plus recommendation demo seed data across all 50 states.
- Add backend test coverage for recommendation preferences, queue filtering, interaction recording, favorites integration, and role protection.